### PR TITLE
Backend: Implement /session endpoint

### DIFF
--- a/backend/src/core/session_store.py
+++ b/backend/src/core/session_store.py
@@ -1,0 +1,36 @@
+"""In-memory session store for agent state."""
+
+from __future__ import annotations
+
+from threading import Lock
+from uuid import uuid4
+
+from src.core.models import AgentState
+
+
+_session_store: dict[str, AgentState] = {}
+_store_lock = Lock()
+
+
+def create_session(variant: str) -> tuple[str, AgentState]:
+    """Create a new session and initialize agent state."""
+
+    session_id = str(uuid4())
+    state = AgentState(variant=variant)
+    with _store_lock:
+        _session_store[session_id] = state
+    return session_id, state
+
+
+def get_session(session_id: str) -> AgentState | None:
+    """Retrieve a session by id."""
+
+    with _store_lock:
+        return _session_store.get(session_id)
+
+
+def reset_store() -> None:
+    """Clear the in-memory session store (for tests)."""
+
+    with _store_lock:
+        _session_store.clear()

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -4,8 +4,14 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
+from src.core.session_store import get_session, reset_store
 
 client = TestClient(app)
+
+
+def setup_function() -> None:
+    """Reset session store before each test."""
+    reset_store()
 
 
 def test_root_endpoint() -> None:
@@ -27,3 +33,24 @@ def test_health_check_endpoint() -> None:
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "healthy"
+
+
+def test_session_endpoint_creates_session() -> None:
+    """Test /session endpoint creates session and stores state."""
+    response = client.post("/session", json={"variant": "US"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["session_id"]
+    assert data["variant"] == "US"
+    assert data["created_at"]
+
+    stored = get_session(data["session_id"])
+    assert stored is not None
+    assert stored.variant == "US"
+
+
+def test_session_endpoint_rejects_invalid_variant() -> None:
+    """Test /session endpoint rejects invalid variants."""
+    response = client.post("/session", json={"variant": "ZZ"})
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid variant"

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "test": "cd backend && pytest"
+  },
   "dependencies": {
     "mayor-west-mode": "github:shyamsridhar123/MayorWest"
   }


### PR DESCRIPTION
Fixes #6

## Summary
- add /session endpoint with validation and in-memory store
- initialize session agent state
- add tests for session endpoint

## Testing
- npm test